### PR TITLE
Fix mid-tier RECENT file starvation in rmirror cascades

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,20 @@
+2026-05-23  Ask Bjørn Hansen  <ask@develooper.com>
+
+	* fix rmirror mid-tier RECENT file starvation in mirror cascades:
+	re-seed the interval files every loop instead of gating it on RECENT-Z
+	reaching uptodateness within a single loop budget, which never happens
+	on large trees so only the principal file stayed fresh
+
+	* guard _rmirror_reseed against an undef minmax.max on a not-yet-fetched
+	larger file so the forked child can no longer die in _bigfloatlt
+
+	* split the loop time budget into maximum_time_per_loop (work budget per
+	pass) and minimum_time_per_loop (throttle floor), both default 20; expose
+	--maximum-time-per-loop and --minimum-time-per-loop on rrr-client
+
+	* add t/07-reseed-undef-minmax.t (deterministic) and t/06-interval-propagation.t
+	(AUTHOR_TEST-gated end-to-end repro)
+
 2020-06-21  k  <andk@cpan.org>
 
 	* release 0.4.6

--- a/MANIFEST
+++ b/MANIFEST
@@ -26,6 +26,8 @@ t/02-operation.t
 t/03-done.t
 t/04-run.t
 t/05-bugtracker.t
+t/06-interval-propagation.t
+t/07-reseed-undef-minmax.t
 t/70_critic.t
 t/perlcriticrc
 t/pod-coverage.t

--- a/bin/rrr-client
+++ b/bin/rrr-client
@@ -31,6 +31,20 @@ Prints a brief message and exits.
 Defaults to 20000. Same as max_files_per_connection in
 File::Rsync::Mirror::Recent
 
+=item B<--maximum-time-per-loop=f>
+
+Work budget per mirror loop in seconds; same as maximum_time_per_loop in
+File::Rsync::Mirror::Recent. Defaults to 20. Raise it to transfer more
+per pass before yielding to re-check the principal and reseed lagging
+interval files.
+
+=item B<--minimum-time-per-loop=f>
+
+Throttle floor per mirror loop in seconds; same as minimum_time_per_loop
+in File::Rsync::Mirror::Recent. Defaults to 20. The minimum wall-clock
+length of a loop, so an idle client does not reconnect upstream more
+often than this.
+
 =item B<--password=s>
 
 Password if the rsync source requires it.  Can also be set by setting
@@ -121,6 +135,8 @@ my $rrr = File::Rsync::Mirror::Recent->new
                      ($Opt{tmpdir} ? ('temp-dir' => $Opt{tmpdir}) : ()),
                     },
    ($Opt{runstatusfile} ? (runstatusfile => $Opt{runstatusfile}) : ()),
+   (defined $Opt{"maximum-time-per-loop"} ? (maximum_time_per_loop => $Opt{"maximum-time-per-loop"}) : ()),
+   (defined $Opt{"minimum-time-per-loop"} ? (minimum_time_per_loop => $Opt{"minimum-time-per-loop"}) : ()),
    ($Opt{tmpdir} ? (tempdir => $Opt{tmpdir}) : ()),
    verbose => $Opt{verbose},
    ($Opt{verboselog}    ? (verboselog    => $Opt{verboselog})    : ()),

--- a/lib/File/Rsync/Mirror/Recent.pm
+++ b/lib/File/Rsync/Mirror/Recent.pm
@@ -160,6 +160,10 @@ BEGIN {
          "_max_one_state",        # when we have no time left but want
                                   # at least get one file per
                                   # iteration to avoid procrastination
+         "minimum_time_per_loop", # minimum seconds budget per rmirror
+                                  # loop; defaults to 20 (see rmirror).
+                                  # Test seam: lower values let a loop
+                                  # bail out before the chain is current.
          "_principal_recentfile",
          "_recentfiles",
          "_rsync",
@@ -637,9 +641,9 @@ sub rmirror {
         # XXX exit gracefully (reminder)
     };
 
-    # XXX needs accessor: warning, if set too low, we do nothing but
-    # mirror the principal!
-    my $minimum_time_per_loop = 20;
+    # warning: if set too low, we do nothing but mirror the principal!
+    my $minimum_time_per_loop = $self->minimum_time_per_loop;
+    $minimum_time_per_loop = 20 unless defined $minimum_time_per_loop;
 
     if (my $logfile = $self->_logfilefordone) {
         for my $i (0..$#$rfs) {

--- a/lib/File/Rsync/Mirror/Recent.pm
+++ b/lib/File/Rsync/Mirror/Recent.pm
@@ -720,6 +720,14 @@ sub _rmirror_loop {
                 }
             }
             $self->_max_one_state(0);
+            # Re-seed mid-tier (non-principal) interval files every loop,
+            # independent of whether the full-history file (RECENT-Z) has
+            # become uptodate within this loop's time budget. Otherwise, when
+            # RECENT-Z is large and cannot finish in one budget, the mid-tier
+            # files would never get re-seeded and the client's copy of those
+            # index files would freeze while the principal stays fresh. The
+            # re-seed condition is self-limiting, so this does not thrash.
+            $self->_rmirror_reseed;
             my $exit = 0;
             if ($rfs->[-1]->uptodate) {
                 $self->_rmirror_cleanup;
@@ -778,12 +786,8 @@ sub _rmirror_sleep_per_connection {
     $rfs->[$i+1]->done->merge($rf->done) if $i < $#$rfs;
 }
 
-sub _rmirror_cleanup {
+sub _rmirror_reseed {
     my($self) = @_;
-    my $pathdb = $self->_pathdb();
-    for my $k (keys %$pathdb) {
-        delete $pathdb->{$k};
-    }
     my $rfs = $self->recentfiles;
     for my $i (0..$#$rfs-1) {
         my $thismerged = $rfs->[$i]->merged;
@@ -792,6 +796,14 @@ sub _rmirror_cleanup {
         if (not defined $thismerged->{epoch} or _bigfloatlt($nextminmax->{max},$thismerged->{epoch})){
             $next->seed;
         }
+    }
+}
+
+sub _rmirror_cleanup {
+    my($self) = @_;
+    my $pathdb = $self->_pathdb();
+    for my $k (keys %$pathdb) {
+        delete $pathdb->{$k};
     }
 }
 

--- a/lib/File/Rsync/Mirror/Recent.pm
+++ b/lib/File/Rsync/Mirror/Recent.pm
@@ -194,6 +194,11 @@ as in F:R:M:Recentfile
 
 as in F:R:M:Recentfile
 
+=item minimum_time_per_loop
+
+The minimum seconds budget that a single C<rmirror> loop iteration is
+allowed to spend. Defaults to 20.
+
 =item remote
 
 The remote principal recentfile in rsync notation. E.g.
@@ -793,7 +798,9 @@ sub _rmirror_reseed {
         my $thismerged = $rfs->[$i]->merged;
         my $next = $rfs->[$i+1];
         my $nextminmax = $next->minmax;
-        if (not defined $thismerged->{epoch} or _bigfloatlt($nextminmax->{max},$thismerged->{epoch})){
+        if (not defined $thismerged->{epoch}
+            or not defined $nextminmax->{max}
+            or _bigfloatlt($nextminmax->{max},$thismerged->{epoch})){
             $next->seed;
         }
     }

--- a/lib/File/Rsync/Mirror/Recent.pm
+++ b/lib/File/Rsync/Mirror/Recent.pm
@@ -160,10 +160,15 @@ BEGIN {
          "_max_one_state",        # when we have no time left but want
                                   # at least get one file per
                                   # iteration to avoid procrastination
-         "minimum_time_per_loop", # minimum seconds budget per rmirror
-                                  # loop; defaults to 20 (see rmirror).
-                                  # Test seam: lower values let a loop
-                                  # bail out before the chain is current.
+         "maximum_time_per_loop", # work budget: seconds one rmirror loop
+                                  # keeps mirroring before it yields to
+                                  # re-check the principal, reseed lagging
+                                  # interval files and write the status
+                                  # file; defaults to 20 (see rmirror).
+         "minimum_time_per_loop", # throttle floor: minimum wall-clock
+                                  # length of one rmirror loop, so an idle
+                                  # client does not reconnect upstream more
+                                  # often than this; defaults to 20.
          "_principal_recentfile",
          "_recentfiles",
          "_rsync",
@@ -194,10 +199,20 @@ as in F:R:M:Recentfile
 
 as in F:R:M:Recentfile
 
+=item maximum_time_per_loop
+
+The work budget for a single C<rmirror> loop iteration: the number of
+seconds the loop keeps mirroring files before it yields to re-check the
+principal recentfile, reseed any lagging interval files and write the run
+status file. Defaults to 20. Raise it to let a busy mirror transfer more
+per pass (fewer yields); lower it to react to upstream changes sooner.
+
 =item minimum_time_per_loop
 
-The minimum seconds budget that a single C<rmirror> loop iteration is
-allowed to spend. Defaults to 20.
+The throttle floor for a single C<rmirror> loop iteration: its minimum
+wall-clock length. If a loop finishes its work sooner, it sleeps out the
+remainder, so an idle client does not reconnect to the upstream more
+often than this. Defaults to 20.
 
 =item remote
 
@@ -646,9 +661,13 @@ sub rmirror {
         # XXX exit gracefully (reminder)
     };
 
-    # warning: if set too low, we do nothing but mirror the principal!
+    # The work budget bounds how long each loop mirrors before yielding;
+    # the throttle floor is the minimum wall-clock length of a loop. Both
+    # default to 20 seconds.
     my $minimum_time_per_loop = $self->minimum_time_per_loop;
     $minimum_time_per_loop = 20 unless defined $minimum_time_per_loop;
+    my $maximum_time_per_loop = $self->maximum_time_per_loop;
+    $maximum_time_per_loop = 20 unless defined $maximum_time_per_loop;
 
     if (my $logfile = $self->_logfilefordone) {
         for my $i (0..$#$rfs) {
@@ -677,13 +696,17 @@ sub rmirror {
         $self->_rmirror_runstatusfile_write ($rstfile, \%options);
         $self->_have_written_statusfile(1);
     }
-    $self->_rmirror_loop($minimum_time_per_loop,\%options);
+    $self->_rmirror_loop($minimum_time_per_loop,$maximum_time_per_loop,\%options);
 }
 
 sub _rmirror_loop {
-    my($self,$minimum_time_per_loop,$options) = @_;
+    my($self,$minimum_time_per_loop,$maximum_time_per_loop,$options) = @_;
   LOOP: while () {
-        my $ttleave = time + $minimum_time_per_loop;
+        my $loopstart = time;
+        # $ttleave bounds the mirroring work in this pass (the maximum
+        # budget). The end-of-loop sleep below pads a short loop up to the
+        # minimum period. These were a single knob historically.
+        my $ttleave = $loopstart + $maximum_time_per_loop;
         my $rstfile = $self->runstatusfile;
         my $otherproc = $self->_thaw_without_pathdb ($rstfile);
         my $pid = fork;
@@ -749,7 +772,7 @@ sub _rmirror_loop {
         if (!$options->{loop} && $otherproc && $otherproc->recentfiles->[-1]->uptodate) {
             last LOOP;
         }
-        my $sleep = $ttleave - time;
+        my $sleep = $loopstart + $minimum_time_per_loop - time;
         if ($sleep > 0.01) {
             $self->_rmirror_endofloop_sleep ($sleep);
         } else {

--- a/t/06-interval-propagation.t
+++ b/t/06-interval-propagation.t
@@ -1,0 +1,288 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+=head1 NAME
+
+06-interval-propagation.t - mid-tier RECENT index files must keep
+advancing on a client while the slow C<RECENT-Z> file is behind
+
+=head1 DESCRIPTION
+
+Reproduces a production bug in C<rmirror(loop =E<gt> 1)> (the daemon mode
+used by C<bin/rrr-client>).
+
+A client mirrors a chain of recentfiles smallest-interval-first. Each loop
+re-fetches the principal and processes the chain up to C<RECENT-Z.yaml>.
+C<_rmirror_cleanup> re-seeds mid-tier interval files (so the client keeps
+re-fetching them after they have reached uptodateness and unseeded), but it
+is called only:
+
+    if ($rfs->[-1]->uptodate) {        # $rfs->[-1] is RECENT-Z
+        $self->_rmirror_cleanup;
+    }
+
+When C<RECENT-Z> is large and the per-loop time budget
+(C<minimum_time_per_loop>) is small, a loop cannot bring C<Z> up to date.
+Uptodateness for C<Z> is therefore never reached, the gate stays false and
+C<_rmirror_cleanup> never runs. Meanwhile the smaller interval files reach
+uptodateness, unseed, and -- with no re-seed -- stop being re-fetched.
+
+The observable effect: as events age out of the principal into a mid-tier
+(e.g. C<RECENT-5s.yaml>) on the server, the server's mid-tier index keeps
+advancing, but the I<client's> copy of that index freezes. A mirror that
+mirrors downstream of this client reads the frozen index and permanently
+misses those events.
+
+=head2 What this test does
+
+  1. Build a server tree with a small working set plus a large Z-only
+     backlog so that, under a tight budget, RECENT-Z can never finish.
+  2. Run rmirror(loop => 1) in a child process.
+  3. Wait until the runstatusfile shows the bug-triggering steady state:
+     a mid-tier (5s) has reached uptodateness and unseeded, while Z has
+     NOT reached uptodateness. (This proves we are exercising the gate,
+     not a setup error or an over-starved chain.)
+  4. Record the frozen max-epoch of the client's RECENT-5s.yaml, then keep
+     churning the server so its RECENT-5s.yaml advances.
+  5. Assert the client's RECENT-5s.yaml advances too.
+
+Currently step 5 FAILS: the client's mid-tier index stays frozen because
+_rmirror_cleanup is gated behind the never-true "Z is uptodate" condition.
+
+C<minimum_time_per_loop> is a non-behavioral test seam (read/write
+accessor / constructor option, defaulting to 20 so production is
+unchanged).
+
+=cut
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use File::Path qw(mkpath rmtree);
+use Time::HiRes qw(time sleep);
+use Cwd ();
+use File::Spec ();
+use POSIX ":sys_wait_h";
+use YAML::Syck ();
+
+use Test::More;
+
+use File::Rsync::Mirror::Recent;
+use File::Rsync::Mirror::Recentfile;
+
+my $root_from  = "t/serv";
+my $root_to    = "t/mirr";
+my $tmpdir     = "t/tmp";
+my $statusfile = "t/recent-rmirror-state.yml";
+
+sub cleanup {
+    rmtree [$root_from, $root_to, $tmpdir];
+    unlink $statusfile;
+    unlink "$statusfile.new";
+    rmdir "$statusfile.lock";
+}
+
+cleanup();
+mkpath $_ for $root_from, $root_to, $tmpdir;
+my $cwd = Cwd::cwd;
+
+# Smallest interval first. Small steps so events age out of the principal
+# quickly; Z is the slow full-history file.
+my @intervals = qw( 2s 3s 5s 8s Z );
+my $midtier   = "5s";
+
+my $rf0 = File::Rsync::Mirror::Recentfile->new
+    (
+     aggregator    => [@intervals[1..$#intervals]],
+     interval      => $intervals[0],
+     localroot     => $root_from,
+     rsync_options => {
+                       compress => 0,
+                       links    => 1,
+                       times    => 1,
+                       checksum => 0,
+                      },
+    );
+
+my $fc = 0;
+sub serv_new {
+    my($dir) = @_;
+    my $rel  = sprintf "%s/f%05d.txt", $dir, ++$fc;
+    my $file = "$root_from/$rel";
+    mkpath "$root_from/$dir";
+    open my $fh, ">", $file or die "Could not open '$file': $!";
+    print $fh "x" x 1024;
+    close $fh or die "Could not close '$file': $!";
+    $rf0->update($file, "new");
+    return $rel;
+}
+
+# max epoch present in a recentfile, or undef
+sub rf_maxepoch {
+    my($root, $interval) = @_;
+    my $f = "$root/RECENT-$interval.yaml";
+    return undef unless -e $f;
+    my $rf = File::Rsync::Mirror::Recentfile->new_from_file($f);
+    my $re = $rf->recent_events;
+    return @$re ? $re->[0]{epoch} : undef;
+}
+
+# read the per-interval reduced state from the runstatusfile
+sub status_rfs {
+    return undef unless -e $statusfile;
+    my $y = eval { YAML::Syck::LoadFile($statusfile) };
+    return undef unless $y;
+    my %by_interval;
+    for my $rf (@{ $y->{reduced_rfs} || [] }) {
+        my $iv = $rf->{'-_interval'};
+        next unless defined $iv;
+        $by_interval{$iv} = {
+            uptodate => $rf->{'-_uptodateness_ever_reached'} ? 1 : 0,
+            seeded   => $rf->{'-_seeded'}                    ? 1 : 0,
+        };
+    }
+    return \%by_interval;
+}
+
+# ---- Build the server tree ---------------------------------------------
+
+# Small working set, aged into Z once so the chain has history.
+serv_new("init") for 1..4;
+$rf0->aggregate;
+sleep 9;
+$rf0->aggregate;
+
+# Large Z-only backlog so a tight-budget loop can never finish RECENT-Z.
+serv_new("bulk") for 1..150;
+$rf0->aggregate;
+sleep 9;
+$rf0->aggregate;
+
+# A little fresh content in the small intervals.
+for (1..3) { serv_new("work"); $rf0->aggregate; sleep 0.4; }
+
+# ---- Client: tight per-loop budget so RECENT-Z cannot finish -----------
+
+my $rrr = File::Rsync::Mirror::Recent->new
+    (
+     ignore_link_stat_errors  => 1,
+     localroot                => $root_to,
+     remote                   => "$root_from/RECENT.recent",
+     max_files_per_connection => 2,
+     _runstatusfile           => $statusfile,
+     minimum_time_per_loop    => 1,   # the seam: tight budget
+     rsync_options            => {
+                                  compress   => 0,
+                                  links      => 1,
+                                  times      => 1,
+                                  checksum   => 0,
+                                  'temp-dir' => "$cwd/$tmpdir",
+                                 },
+    );
+is($rrr->minimum_time_per_loop, 1, "seam: minimum_time_per_loop is injectable");
+
+# Per-connection sleeps keep RECENT-Z's sync time above the budget in a
+# way that does not depend on raw rsync speed.
+for my $rf (@{$rrr->recentfiles}) {
+    $rf->sleep_per_connection(0.12);
+}
+$rrr->_rmirror_sleep_per_connection(0.001);
+
+# ---- Run the daemon loop in a child ------------------------------------
+
+my $pid = fork;
+die "fork failed: $!" unless defined $pid;
+if (!$pid) {
+    # child: the rmirror daemon. Under a tight budget the loop repeatedly
+    # probes RECENT files that do not exist yet and emits benign
+    # "Could not stat ... No such file" warnings; silence them so the TAP
+    # stream stays readable. The behaviour under test is unaffected.
+    open STDERR, ">", File::Spec->devnull or warn "cannot reopen STDERR: $!";
+    $rrr->rmirror(loop => 1);
+    POSIX::_exit(0);
+}
+
+# Wait for the bug-triggering steady state. The condition is: the mid-tier
+# has reached uptodateness while RECENT-Z has NOT, and the client has
+# actually installed its copy of the mid-tier index (so we have a baseline
+# to watch). In that state the cleanup gate ($rfs->[-1]->uptodate) is false.
+# We do not require the mid-tier to be currently unseeded: a working fix
+# re-seeds it via cleanup, so the unseeded snapshot is not always
+# observable -- but "mid-tier uptodate, Z not uptodate" holds either way.
+my $bug_state_deadline = time + 70;
+my $reached_bug_state  = 0;
+my $client_frozen;
+while (time < $bug_state_deadline) {
+    # keep the server's principal (and thus mid-tiers) moving
+    serv_new("churn");
+    $rf0->aggregate;
+    my $st = status_rfs();
+    my $c  = rf_maxepoch($root_to, $midtier);
+    if ($st
+        && $st->{$midtier} && $st->{$midtier}{uptodate}
+        && $st->{Z} && !$st->{Z}{uptodate}
+        && defined $c) {
+        $reached_bug_state = 1;
+        $client_frozen     = $c;   # baseline at onset
+        last;
+    }
+    # A steady ~1s cadence keeps the server churn from starving the daemon
+    # of CPU; churning as fast as possible makes the chain thrash.
+    sleep 1;
+}
+
+ok($reached_bug_state,
+   "reached bug-triggering state: $midtier uptodate while Z not uptodate")
+    or diag "status: " . YAML::Syck::Dump(status_rfs());
+
+my $server_at_freeze = rf_maxepoch($root_from, $midtier);
+diag sprintf "at bug-state onset: client %s max=%s  server %s max=%s",
+    $midtier, (defined $client_frozen ? $client_frozen : "undef"),
+    $midtier, (defined $server_at_freeze ? $server_at_freeze : "undef");
+
+# Keep churning so the server's mid-tier index advances well past the
+# frozen client value, then check whether the client catches up. Without
+# the fix the client's mid-tier index stays frozen; with cleanup re-seeding
+# the mid-tier it advances.
+my $advance_deadline = time + 45;
+my $client_advanced  = 0;
+my $client_latest    = $client_frozen;
+while (time < $advance_deadline) {
+    serv_new("churn");
+    $rf0->aggregate;
+    $client_latest = rf_maxepoch($root_to, $midtier);
+    if (defined $client_latest && defined $client_frozen
+        && $client_latest > $client_frozen) {
+        $client_advanced = 1;
+        last;
+    }
+    sleep 1;
+}
+
+my $server_latest = rf_maxepoch($root_from, $midtier);
+diag sprintf "after churn: client %s max=%s  server %s max=%s",
+    $midtier, (defined $client_latest ? $client_latest : "undef"),
+    $midtier, (defined $server_latest ? $server_latest : "undef");
+
+# Stop the daemon and reap.
+kill 'TERM', $pid;
+kill 'KILL', $pid;
+waitpid($pid, 0);
+1 while waitpid(-1, WNOHANG) > 0;
+
+ok($client_advanced,
+   "client's RECENT-$midtier index advanced (mid-tier kept fresh by cleanup)")
+    or diag "client RECENT-$midtier stayed frozen at "
+        . (defined $client_frozen ? $client_frozen : "undef")
+        . " while the server's advanced -- mid-tier re-seed is gated behind "
+        . "RECENT-Z uptodateness";
+
+cleanup();
+done_testing();
+
+# Local Variables:
+# mode: cperl
+# cperl-indent-level: 4
+# End:

--- a/t/06-interval-propagation.t
+++ b/t/06-interval-propagation.t
@@ -23,11 +23,12 @@ is called only:
         $self->_rmirror_cleanup;
     }
 
-When C<RECENT-Z> is large and the per-loop time budget
-(C<minimum_time_per_loop>) is small, a loop cannot bring C<Z> up to date.
+When C<RECENT-Z> is large and the per-loop work budget
+(C<maximum_time_per_loop>) is small, a loop cannot bring C<Z> up to date.
 Uptodateness for C<Z> is therefore never reached, the gate stays false and
-C<_rmirror_cleanup> never runs. Meanwhile the smaller interval files reach
-uptodateness, unseed, and -- with no re-seed -- stop being re-fetched.
+(before the fix) the re-seed never ran. Meanwhile the smaller interval
+files reach uptodateness, unseed, and -- with no re-seed -- stop being
+re-fetched.
 
 The observable effect: as events age out of the principal into a mid-tier
 (e.g. C<RECENT-5s.yaml>) on the server, the server's mid-tier index keeps
@@ -48,12 +49,14 @@ misses those events.
      churning the server so its RECENT-5s.yaml advances.
   5. Assert the client's RECENT-5s.yaml advances too.
 
-Currently step 5 FAILS: the client's mid-tier index stays frozen because
-_rmirror_cleanup is gated behind the never-true "Z is uptodate" condition.
+Before the fix, step 5 FAILED: the client's mid-tier index stayed frozen
+because the re-seed was gated behind the never-true "Z is uptodate"
+condition. The fix runs C<_rmirror_reseed> every loop, independent of that
+gate, so step 5 now passes.
 
-C<minimum_time_per_loop> is a non-behavioral test seam (read/write
-accessor / constructor option, defaulting to 20 so production is
-unchanged).
+C<maximum_time_per_loop> (the work budget) and C<minimum_time_per_loop>
+(the throttle floor) are non-behavioral seams (read/write accessors /
+constructor options, each defaulting to 20 so production is unchanged).
 
 =head2 Why this is an AUTHOR_TEST
 
@@ -207,7 +210,8 @@ my $rrr = File::Rsync::Mirror::Recent->new
      remote                   => "$root_from/RECENT.recent",
      max_files_per_connection => 2,
      _runstatusfile           => $statusfile,
-     minimum_time_per_loop    => 1,   # the seam: tight budget
+     maximum_time_per_loop    => 1,   # the seam: tight work budget so a
+     minimum_time_per_loop    => 1,   # loop can never finish RECENT-Z
      rsync_options            => {
                                   compress   => 0,
                                   links      => 1,
@@ -216,7 +220,7 @@ my $rrr = File::Rsync::Mirror::Recent->new
                                   'temp-dir' => "$cwd/$tmpdir",
                                  },
     );
-is($rrr->minimum_time_per_loop, 1, "seam: minimum_time_per_loop is injectable");
+is($rrr->maximum_time_per_loop, 1, "seam: maximum_time_per_loop is injectable");
 
 # Per-connection sleeps keep RECENT-Z's sync time above the budget in a
 # way that does not depend on raw rsync speed.

--- a/t/06-interval-propagation.t
+++ b/t/06-interval-propagation.t
@@ -55,6 +55,26 @@ C<minimum_time_per_loop> is a non-behavioral test seam (read/write
 accessor / constructor option, defaulting to 20 so production is
 unchanged).
 
+=head2 Why this is an AUTHOR_TEST
+
+This test drives a real C<rmirror(loop =E<gt> 1)> daemon in a child
+process and watches it converge through several timing-dependent states
+(mid-tier reaching uptodateness, RECENT-Z staying behind, the client
+re-fetching an advancing mid-tier index). On a loaded machine the
+convergence simply takes longer; there is no fast, fully deterministic
+way to provoke "RECENT-Z perpetually behind while mid-tier keeps
+advancing" without real elapsed time. Like C<t/02-aurora.t> it is
+therefore gated behind C<AUTHOR_TEST> and skipped by default so the
+normal C<make test> / C<prove> suite stays stable. Run it with:
+
+    AUTHOR_TEST=1 perl -Ilib t/06-interval-propagation.t
+
+Under C<AUTHOR_TEST> it is hardened to be reliable rather than fast: it
+uses generous deadlines (it may run a couple of minutes), separates the
+"client has installed its first RECENT-5s" precondition from the
+advancement assertion, and guards every epoch comparison against undef
+so it never compares against a missing baseline.
+
 =cut
 
 use FindBin;
@@ -68,6 +88,21 @@ use POSIX ":sys_wait_h";
 use YAML::Syck ();
 
 use Test::More;
+
+my $tests = 4;
+
+BEGIN {
+    unless ($ENV{AUTHOR_TEST}) {
+        # Timing-sensitive: drives a real rmirror daemon and waits for
+        # several timing-dependent states to converge. Skipped by default
+        # to keep the suite stable; run under AUTHOR_TEST.
+        Test::More::plan(skip_all =>
+            "timing-sensitive test; to run, set env AUTHOR_TEST=1 "
+            . "(e.g. AUTHOR_TEST=1 perl -Ilib t/06-interval-propagation.t)");
+    }
+}
+
+plan tests => $tests;
 
 use File::Rsync::Mirror::Recent;
 use File::Rsync::Mirror::Recentfile;
@@ -204,17 +239,28 @@ if (!$pid) {
     POSIX::_exit(0);
 }
 
-# Wait for the bug-triggering steady state. The condition is: the mid-tier
-# has reached uptodateness while RECENT-Z has NOT, and the client has
-# actually installed its copy of the mid-tier index (so we have a baseline
-# to watch). In that state the cleanup gate ($rfs->[-1]->uptodate) is false.
+# ---- Phase 1: reach the bug-exercising precondition --------------------
+#
+# Precondition (NOT the thing under test, just the state in which the bug
+# can manifest): the mid-tier has reached uptodateness while RECENT-Z has
+# NOT, AND the client has actually installed its first copy of the mid-tier
+# index so we have a non-undef baseline to watch. In that state the cleanup
+# gate ($rfs->[-1]->uptodate) is false.
+#
 # We do not require the mid-tier to be currently unseeded: a working fix
 # re-seeds it via cleanup, so the unseeded snapshot is not always
-# observable -- but "mid-tier uptodate, Z not uptodate" holds either way.
-my $bug_state_deadline = time + 70;
-my $reached_bug_state  = 0;
-my $client_frozen;
-while (time < $bug_state_deadline) {
+# observable -- but "mid-tier uptodate, Z not uptodate, client copy present"
+# holds either way.
+#
+# Generous deadline: on a loaded machine convergence just takes longer, and
+# the fix adds per-loop re-seed work under the tight 1s budget. Reaching the
+# precondition is a setup step, so we wait as long as needed (within reason)
+# rather than proceeding with an undef baseline.
+my $PRECONDITION_TIMEOUT = 150;   # seconds; setup, not the assertion
+my $precondition_deadline = time + $PRECONDITION_TIMEOUT;
+my $reached_precondition  = 0;
+my $client_frozen;                # client mid-tier baseline at onset
+while (time < $precondition_deadline) {
     # keep the server's principal (and thus mid-tiers) moving
     serv_new("churn");
     $rf0->aggregate;
@@ -224,8 +270,8 @@ while (time < $bug_state_deadline) {
         && $st->{$midtier} && $st->{$midtier}{uptodate}
         && $st->{Z} && !$st->{Z}{uptodate}
         && defined $c) {
-        $reached_bug_state = 1;
-        $client_frozen     = $c;   # baseline at onset
+        $reached_precondition = 1;
+        $client_frozen        = $c;   # defined baseline at onset
         last;
     }
     # A steady ~1s cadence keeps the server churn from starving the daemon
@@ -233,32 +279,52 @@ while (time < $bug_state_deadline) {
     sleep 1;
 }
 
-ok($reached_bug_state,
-   "reached bug-triggering state: $midtier uptodate while Z not uptodate")
-    or diag "status: " . YAML::Syck::Dump(status_rfs());
+ok($reached_precondition,
+   "reached bug-exercising precondition: $midtier uptodate while Z not "
+   . "uptodate and client has installed its first RECENT-$midtier")
+    or diag "precondition not reached within ${PRECONDITION_TIMEOUT}s; "
+        . "client $midtier baseline is "
+        . (defined $client_frozen ? $client_frozen : "undef")
+        . "; status: " . YAML::Syck::Dump(status_rfs());
+
+# Independently assert we captured a usable (defined) baseline. Everything
+# downstream compares against this; an undef baseline must never silently
+# pass an advancement check.
+ok(defined $client_frozen,
+   "captured a defined client RECENT-$midtier baseline before churn");
 
 my $server_at_freeze = rf_maxepoch($root_from, $midtier);
-diag sprintf "at bug-state onset: client %s max=%s  server %s max=%s",
+diag sprintf "at precondition onset: client %s max=%s  server %s max=%s",
     $midtier, (defined $client_frozen ? $client_frozen : "undef"),
     $midtier, (defined $server_at_freeze ? $server_at_freeze : "undef");
 
-# Keep churning so the server's mid-tier index advances well past the
-# frozen client value, then check whether the client catches up. Without
-# the fix the client's mid-tier index stays frozen; with cleanup re-seeding
-# the mid-tier it advances.
-my $advance_deadline = time + 45;
+# ---- Phase 2: the actual assertion -------------------------------------
+#
+# Keep churning so the server's mid-tier index advances well past the frozen
+# client value, then check whether the client catches up. Without the fix
+# the client's mid-tier index stays frozen (cleanup, which re-seeds the
+# mid-tier, is gated behind the never-true "Z is uptodate"); with the fix
+# _rmirror_reseed runs every loop and the client's mid-tier keeps advancing.
+#
+# This is a robust, non-transient signal: we wait until the client's
+# max-epoch strictly exceeds the baseline. Only run it if we have a defined
+# baseline -- otherwise the comparison would be meaningless.
+my $ADVANCE_TIMEOUT  = 90;   # seconds; generous for a loaded machine
+my $advance_deadline = time + $ADVANCE_TIMEOUT;
 my $client_advanced  = 0;
 my $client_latest    = $client_frozen;
-while (time < $advance_deadline) {
-    serv_new("churn");
-    $rf0->aggregate;
-    $client_latest = rf_maxepoch($root_to, $midtier);
-    if (defined $client_latest && defined $client_frozen
-        && $client_latest > $client_frozen) {
-        $client_advanced = 1;
-        last;
+if (defined $client_frozen) {
+    while (time < $advance_deadline) {
+        serv_new("churn");
+        $rf0->aggregate;
+        my $c = rf_maxepoch($root_to, $midtier);
+        $client_latest = $c if defined $c;
+        if (defined $c && $c > $client_frozen) {
+            $client_advanced = 1;
+            last;
+        }
+        sleep 1;
     }
-    sleep 1;
 }
 
 my $server_latest = rf_maxepoch($root_from, $midtier);
@@ -273,14 +339,17 @@ waitpid($pid, 0);
 1 while waitpid(-1, WNOHANG) > 0;
 
 ok($client_advanced,
-   "client's RECENT-$midtier index advanced (mid-tier kept fresh by cleanup)")
+   "client's RECENT-$midtier index advanced past baseline "
+   . "(mid-tier kept fresh by per-loop re-seed)")
     or diag "client RECENT-$midtier stayed frozen at "
         . (defined $client_frozen ? $client_frozen : "undef")
-        . " while the server's advanced -- mid-tier re-seed is gated behind "
-        . "RECENT-Z uptodateness";
+        . " (latest "
+        . (defined $client_latest ? $client_latest : "undef")
+        . ") while the server's advanced to "
+        . (defined $server_latest ? $server_latest : "undef")
+        . " -- mid-tier re-seed is gated behind RECENT-Z uptodateness";
 
 cleanup();
-done_testing();
 
 # Local Variables:
 # mode: cperl

--- a/t/07-reseed-undef-minmax.t
+++ b/t/07-reseed-undef-minmax.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+
+# Regression test for _rmirror_reseed dying when the larger (next)
+# recentfile in the chain has an undefined minmax->{max} while the
+# smaller file already carries a defined merged->{epoch}.
+#
+# Before the undef guard in _rmirror_reseed, _bigfloatlt(undef, <def>)
+# was reached and died with "but both must be defined", which happened
+# in the forked daemon child and made rmirror(loop=>1) spin silently.
+
+use Test::More;
+use lib "lib";
+use File::Rsync::Mirror::Recent;
+use File::Rsync::Mirror::Recentfile;
+
+# Build a tiny two-element chain by hand. We avoid setting interval so
+# that merged()'s into_interval sanity checks stay quiet, and set the
+# accessor-backed fields (_merged / minmax / _recentfiles) directly.
+sub make_chain {
+    my(%args) = @_;
+    my $small = File::Rsync::Mirror::Recentfile->new;
+    my $large = File::Rsync::Mirror::Recentfile->new;
+    $small->merged($args{small_merged});
+    # The larger file was never (successfully) fetched this run, so its
+    # minmax has no max (Recentfile only sets min/max if there were
+    # entries).
+    $large->minmax($args{large_minmax});
+    my $rec = File::Rsync::Mirror::Recent->new(_recentfiles => [$small, $large]);
+    return ($rec, $small, $large);
+}
+
+{
+    # Smaller file has a defined merged.epoch, larger file has undef
+    # minmax.max -> must not die, and must (re)seed the larger file.
+    my($rec, $small, $large) = make_chain(
+        small_merged => { epoch => "1716000000.5" },
+        large_minmax => { mtime => 1716000000 }, # no max key -> undef
+    );
+    is $large->seeded, 0, "larger file starts unseeded";
+    my $ok = eval { $rec->_rmirror_reseed; 1 };
+    ok $ok, "_rmirror_reseed survives undef minmax.max with defined merged.epoch"
+        or diag "died: $@";
+    is $large->seeded, 1, "larger file got (re)seeded because it is behind";
+}
+
+{
+    # Smaller file has undef merged.epoch -> original behavior, the
+    # first branch short-circuits and we still seed (and do not die).
+    my($rec, $small, $large) = make_chain(
+        small_merged => { epoch => undef },
+        large_minmax => { mtime => 1716000000 },
+    );
+    my $ok = eval { $rec->_rmirror_reseed; 1 };
+    ok $ok, "_rmirror_reseed survives undef merged.epoch";
+    is $large->seeded, 1, "larger file got seeded when merged.epoch is undef";
+}
+
+done_testing;


### PR DESCRIPTION
## Problem

In a cascade of mirrors, mid-tier interval RECENT files (`RECENT-6h`, `RECENT-1d`, …) stop updating while only the principal (`RECENT-1h`) stays fresh. Downstream third-party mirrors then miss any event that ages out of the 1h window before they catch it. A periodic full `rsync` of the RECENT files used to mask this.

Root cause: in `rmirror(loop => 1)`, mid-tier re-seeding (`_rmirror_cleanup`) was gated behind `RECENT-Z` reaching uptodateness *within a single loop's time budget*. On CPAN-scale data `RECENT-Z` never finishes inside the budget, so the gate never opens and the mid-tiers starve.

## Fix

- Extract re-seeding into `_rmirror_reseed` and run it every loop, decoupled from the `RECENT-Z` uptodate gate. `_rmirror_cleanup` now only flushes the path db (still gated, as before).
- Guard `_rmirror_reseed` against an undef `minmax.max` on a not-yet-fetched larger file (treated as "needs seed") so it can't die in the forked child.
- Split the overloaded loop-time knob into two accessors: `maximum_time_per_loop` (work budget per pass) and `minimum_time_per_loop` (throttle floor). Both default to 20, so behavior is unchanged unless tuned. Exposed as `--maximum-time-per-loop` / `--minimum-time-per-loop` on `rrr-client`.

## Tests

- `t/07-reseed-undef-minmax.t` — fast, deterministic; runs in the default suite. Asserts `_rmirror_reseed` re-seeds and never dies on undef `minmax.max`.
- `t/06-interval-propagation.t` — end-to-end repro driving a real `rmirror(loop => 1)` daemon; AUTHOR_TEST-gated (timing-sensitive), following the `t/02-aurora.t` convention.

Full suite green under perlbrew perl 5.38.2.
